### PR TITLE
Add pydantic-settings dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ python = "^3.13"
 fastapi = "^0.115.0"
 uvicorn = "^0.30.6"
 pydantic = { version = "^2.9.2", extras = ["email"] }
+pydantic-settings = "^2.0.0"
 sqlalchemy = "^2.0.34"
 alembic = "^1.13.2"
 psycopg = { version = "^3.2.9", extras = ["binary"] }


### PR DESCRIPTION
## Summary
- add pydantic-settings dependency to Poetry configuration

## Testing
- `poetry lock` *(fails: All attempts to connect to pypi.org failed)*
- `poetry install` *(fails: pyproject.toml changed significantly since poetry.lock was last generated)*
- `python - <<'PY'
from app.settings import settings
print(settings.app_env)
PY` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_689dc0dcc79483328f0b514a7d8de41c