### PR TITLE
Use list annotations for screenplay JSONB fields

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import uuid
 from datetime import datetime
 from sqlalchemy import String, Text, ForeignKey, func
@@ -6,11 +7,14 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from sqlalchemy.sql.sqltypes import DateTime
 
+
 def gen_uuid() -> str:
     return str(uuid.uuid4())
 
+
 class Base(DeclarativeBase):
     pass
+
 
 class User(Base):
     __tablename__ = "users"
@@ -18,11 +22,20 @@ class User(Base):
     email: Mapped[str] = mapped_column(String(320), unique=True, index=True)
     full_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
     password_hash: Mapped[str] = mapped_column(String(200))
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
 
-    projects: Mapped[list["Project"]] = relationship(back_populates="owner", cascade="all, delete-orphan")
-    screenplays: Mapped[list["Screenplay"]] = relationship(back_populates="owner", cascade="all, delete-orphan")
+    projects: Mapped[list["Project"]] = relationship(
+        back_populates="owner", cascade="all, delete-orphan"
+    )
+    screenplays: Mapped[list["Screenplay"]] = relationship(
+        back_populates="owner", cascade="all, delete-orphan"
+    )
+
 
 class Project(Base):
     __tablename__ = "projects"
@@ -30,27 +43,42 @@ class Project(Base):
     name: Mapped[str] = mapped_column(String(128))
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     owner_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
 
     owner: Mapped["User"] = relationship(back_populates="projects")
+
 
 class Screenplay(Base):
     __tablename__ = "screenplays"
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
-    project_id: Mapped[str] = mapped_column(ForeignKey("projects.id", ondelete="CASCADE"), index=True)
-    owner_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    project_id: Mapped[str] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), index=True
+    )
+    owner_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
     title: Mapped[str] = mapped_column(String(200))
     logline: Mapped[str | None] = mapped_column(Text, nullable=True)
     state: Mapped[str] = mapped_column(String(16), default="S1")
 
-    turning_points: Mapped[dict] = mapped_column(JSONB, default=list)   # guardamos listas como JSONB
-    characters: Mapped[dict]      = mapped_column(JSONB, default=list)
-    subplots: Mapped[dict]        = mapped_column(JSONB, default=list)
-    locations: Mapped[dict]       = mapped_column(JSONB, default=list)
-    scenes: Mapped[dict]          = mapped_column(JSONB, default=list)
+    turning_points: Mapped[list[dict]] = mapped_column(
+        JSONB, default=list
+    )  # guardamos listas como JSONB
+    characters: Mapped[list[dict]] = mapped_column(JSONB, default=list)
+    subplots: Mapped[list[dict]] = mapped_column(JSONB, default=list)
+    locations: Mapped[list[dict]] = mapped_column(JSONB, default=list)
+    scenes: Mapped[list[dict]] = mapped_column(JSONB, default=list)
 
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
 
     owner: Mapped["User"] = relationship(back_populates="screenplays")

--- a/app/screenplays/router.py
+++ b/app/screenplays/router.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from datetime import datetime, timezone
 from typing import Annotated, Optional, Literal
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -11,13 +10,15 @@ from app.db.models import Screenplay, Project
 router = APIRouter(prefix="/screenplays", tags=["Screenplays"])
 
 WorkflowState = Literal[
-    "S1","S2","S3","S4","S5","S6","S7","S8","S9","DONE","ON_HOLD","RESUME"
+    "S1", "S2", "S3", "S4", "S5", "S6", "S7", "S8", "S9", "DONE", "ON_HOLD", "RESUME"
 ]
+
 
 class TurningPoint(BaseModel):
     id: str
     title: str
     description: str
+
 
 class Character(BaseModel):
     id: str
@@ -27,15 +28,18 @@ class Character(BaseModel):
     conflict: Optional[str] = None
     arc: Optional[str] = None
 
+
 class Subplot(BaseModel):
     id: str
     logline: str
     relevance: Optional[str] = None
 
+
 class Location(BaseModel):
     id: str
     name: str
     details: Optional[str] = None
+
 
 class Scene(BaseModel):
     id: str
@@ -43,10 +47,12 @@ class Scene(BaseModel):
     content: str
     order: int
 
+
 class ScreenplayCreate(BaseModel):
     project_id: str
     title: str
     logline: Optional[str] = None
+
 
 class ScreenplayUpdate(BaseModel):
     title: Optional[str] = Field(default=None, min_length=1)
@@ -57,6 +63,7 @@ class ScreenplayUpdate(BaseModel):
     subplots: Optional[list[Subplot]] = None
     locations: Optional[list[Location]] = None
     scenes: Optional[list[Scene]] = None
+
 
 class ScreenplayOut(BaseModel):
     id: str
@@ -73,10 +80,17 @@ class ScreenplayOut(BaseModel):
     created_at: str
     updated_at: str
 
-def _iso(dt): return dt.isoformat()
+
+def _iso(dt):
+    return dt.isoformat()
+
 
 @router.post("", response_model=ScreenplayOut, status_code=201)
-async def create_screenplay(payload: ScreenplayCreate, me: Annotated[UserPublic, Depends(get_current_user)], session: Annotated[AsyncSession, Depends(get_session)]):
+async def create_screenplay(
+    payload: ScreenplayCreate,
+    me: Annotated[UserPublic, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+):
     # Verifica que el proyecto es del usuario
     prj = await session.get(Project, payload.project_id)
     if not prj or prj.owner_id != me.id:
@@ -97,35 +111,94 @@ async def create_screenplay(payload: ScreenplayCreate, me: Annotated[UserPublic,
     await session.commit()
     await session.refresh(sp)
     return ScreenplayOut(
-        id=sp.id, project_id=sp.project_id, owner_id=sp.owner_id, title=sp.title, logline=sp.logline,
-        state=sp.state, turning_points=sp.turning_points, characters=sp.characters, subplots=sp.subplots,
-        locations=sp.locations, scenes=sp.scenes, created_at=_iso(sp.created_at), updated_at=_iso(sp.updated_at)
+        id=sp.id,
+        project_id=sp.project_id,
+        owner_id=sp.owner_id,
+        title=sp.title,
+        logline=sp.logline,
+        state=sp.state,
+        turning_points=sp.turning_points,
+        characters=sp.characters,
+        subplots=sp.subplots,
+        locations=sp.locations,
+        scenes=sp.scenes,
+        created_at=_iso(sp.created_at),
+        updated_at=_iso(sp.updated_at),
     )
 
+
 @router.get("/{screenplay_id}", response_model=ScreenplayOut)
-async def get_screenplay(screenplay_id: str, me: Annotated[UserPublic, Depends(get_current_user)], session: Annotated[AsyncSession, Depends(get_session)]):
+async def get_screenplay(
+    screenplay_id: str,
+    me: Annotated[UserPublic, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+):
     sp = await session.get(Screenplay, screenplay_id)
     if not sp or sp.owner_id != me.id:
         raise HTTPException(404, "Screenplay not found.")
     return ScreenplayOut(
-        id=sp.id, project_id=sp.project_id, owner_id=sp.owner_id, title=sp.title, logline=sp.logline,
-        state=sp.state, turning_points=sp.turning_points, characters=sp.characters, subplots=sp.subplots,
-        locations=sp.locations, scenes=sp.scenes, created_at=_iso(sp.created_at), updated_at=_iso(sp.updated_at)
+        id=sp.id,
+        project_id=sp.project_id,
+        owner_id=sp.owner_id,
+        title=sp.title,
+        logline=sp.logline,
+        state=sp.state,
+        turning_points=sp.turning_points,
+        characters=sp.characters,
+        subplots=sp.subplots,
+        locations=sp.locations,
+        scenes=sp.scenes,
+        created_at=_iso(sp.created_at),
+        updated_at=_iso(sp.updated_at),
     )
 
+
 @router.patch("/{screenplay_id}", response_model=ScreenplayOut)
-async def update_screenplay(screenplay_id: str, payload: ScreenplayUpdate, me: Annotated[UserPublic, Depends(get_current_user)], session: Annotated[AsyncSession, Depends(get_session)]):
+async def update_screenplay(
+    screenplay_id: str,
+    payload: ScreenplayUpdate,
+    me: Annotated[UserPublic, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+):
     sp = await session.get(Screenplay, screenplay_id)
     if not sp or sp.owner_id != me.id:
         raise HTTPException(404, "Screenplay not found.")
-    for field in ["title","logline","state","turning_points","characters","subplots","locations","scenes"]:
+    for field in [
+        "title",
+        "logline",
+        "state",
+        "turning_points",
+        "characters",
+        "subplots",
+        "locations",
+        "scenes",
+    ]:
         val = getattr(payload, field)
         if val is not None:
-            setattr(sp, field, val)
+            if field in {
+                "turning_points",
+                "characters",
+                "subplots",
+                "locations",
+                "scenes",
+            }:
+                setattr(sp, field, [item.model_dump() for item in val])
+            else:
+                setattr(sp, field, val)
     await session.commit()
     await session.refresh(sp)
     return ScreenplayOut(
-        id=sp.id, project_id=sp.project_id, owner_id=sp.owner_id, title=sp.title, logline=sp.logline,
-        state=sp.state, turning_points=sp.turning_points, characters=sp.characters, subplots=sp.subplots,
-        locations=sp.locations, scenes=sp.scenes, created_at=_iso(sp.created_at), updated_at=_iso(sp.updated_at)
+        id=sp.id,
+        project_id=sp.project_id,
+        owner_id=sp.owner_id,
+        title=sp.title,
+        logline=sp.logline,
+        state=sp.state,
+        turning_points=sp.turning_points,
+        characters=sp.characters,
+        subplots=sp.subplots,
+        locations=sp.locations,
+        scenes=sp.scenes,
+        created_at=_iso(sp.created_at),
+        updated_at=_iso(sp.updated_at),
     )


### PR DESCRIPTION
## Summary
- annotate screenplay JSONB columns as lists
- serialize Pydantic models to dict lists when updating screenplays

## Testing
- `poetry run ruff check app/db/models.py app/screenplays/router.py`
- `poetry run pytest -q` *(fails: no tests ran)*
- `make migrate` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689dc0dfe36083328d082629f3cd0428