### PR TITLE
feat: add subgenres and project ref to synopsis

### DIFF
--- a/app/ai/prompts.py
+++ b/app/ai/prompts.py
@@ -5,6 +5,7 @@ Contexto:
 - Premisa: {premise}
 - Tema: {theme}
 - Género: {genre}
+- Subgéneros: {subgenres}
 """
 
 TREATMENT_PROMPT = """Escribe un Tratamiento breve (6-10 párrafos) cubriendo el arco de 3 actos.


### PR DESCRIPTION
## Summary
- expand synopsis input to handle subgenres and project ID
- pass subgenres into synopsis prompt and stub persistence

## Testing
- `make lint` *(fails: unused imports in alembic/versions/aae5779358b8_init_schema.py, app/media/router.py)*
- `make test` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_689dc84935c88332b833d2f2ec567cc4