### PR TITLE
feat: add project reference to AI and media inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# StoryLab Backend
+
+## AI and Media Endpoints
+
+Los endpoints que generan contenido aceptan ahora un campo `project_id` para asociar los resultados con un proyecto específico.
+
+### Endpoints afectados
+
+- `POST /ai/treatment`
+- `POST /ai/turning-points`
+- `POST /ai/character`
+- `POST /ai/location`
+- `POST /ai/scene`
+- `POST /ai/dialogue/polish`
+- `POST /ai/review`
+- `POST /ai/image`
+
+### Ejemplo de solicitud
+
+```json
+POST /ai/treatment
+{
+  "project_id": "123",
+  "logline": "Un ejemplo de logline",
+  "tone": "cinematográfico"
+}
+```
+
+```json
+POST /ai/image
+{
+  "project_id": "123",
+  "prompt": "Atardecer en la montaña",
+  "style": "fast"
+}
+```
+

--- a/app/ai/router.py
+++ b/app/ai/router.py
@@ -75,6 +75,7 @@ class TreatmentIn(BaseModel):
     tone: Optional[str] = "cinematográfico"
     audience: Optional[str] = "adulto general"
     references: Optional[str] = None
+    project_id: str
     screenwriter: bool = True
 
 class TreatmentOut(BaseModel):
@@ -100,6 +101,7 @@ class TurningPointsIn(BaseModel):
     genre: str
     theme: str
     premise: str
+    project_id: str
 
 class TurningPointsOut(BaseModel):
     points: list[TurningPointItem]
@@ -131,6 +133,7 @@ class CharacterIn(BaseModel):
     role: str
     goal: Optional[str] = None
     conflict: Optional[str] = None
+    project_id: str
     creative: bool = False
 
 @router.post("/character", response_model=CharacterOut)
@@ -156,6 +159,7 @@ class LocationIn(BaseModel):
     seed_name: str
     genre: str
     notes: Optional[str] = None
+    project_id: str
     creative: bool = False
 
 @router.post("/location", response_model=LocationOut)
@@ -175,6 +179,7 @@ class SceneIn(BaseModel):
     context: str
     goal: str
     style: Optional[str] = "Hollywood estándar"
+    project_id: str
     creative: bool = False
     temperature: Optional[float] = None
     max_tokens: Optional[int] = None
@@ -200,6 +205,7 @@ async def generate_scene(payload: SceneIn, me: Annotated[UserPublic, Depends(get
 # ---------- Dialogue Polish ----------
 class DialogueIn(BaseModel):
     raw: str
+    project_id: str
     creative: bool = False
 
 class DialogueOut(BaseModel):
@@ -216,6 +222,7 @@ async def polish_dialogue(payload: DialogueIn, me: Annotated[UserPublic, Depends
 # ---------- Review ----------
 class ReviewIn(BaseModel):
     text: str
+    project_id: str
     screenwriter: bool = True
 
 class ReviewOut(BaseModel):

--- a/app/media/router.py
+++ b/app/media/router.py
@@ -7,6 +7,7 @@ router = APIRouter(prefix="/ai", tags=["AI","Media"])
 class ImageIn(BaseModel):
     prompt: str
     style: str  # "fast" | "quality"
+    project_id: str
 
 class ImageOut(BaseModel):
     url: str


### PR DESCRIPTION
## Summary
- require project_id on AI content generation payloads
- require project_id on image generation payload
- document project_id requirement for content endpoints

## Testing
- `make lint`
- `make test` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_689dd11f06408332bf87f82ff6514438