### PR TITLE
Use project synopsis when generating treatments

### DIFF
--- a/app/ai/prompts.py
+++ b/app/ai/prompts.py
@@ -9,6 +9,8 @@ Contexto:
 """
 
 TREATMENT_PROMPT = """Escribe un Tratamiento breve (6-10 párrafos) cubriendo el arco de 3 actos.
+Basado en la sinopsis proporcionada.
+- Sinopsis: {synopsis}
 - Tono: {tone}
 - Público: {audience}
 - Referencias: {references}


### PR DESCRIPTION
## Summary
- include `project_id` in treatment payload and validate project with synopsis
- extend treatment prompt to accept a `synopsis` placeholder

## Testing
- `make lint`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dd12c138883329ebc683c4f1c0fa2