### PR TITLE
feat: store project treatment

### DIFF
--- a/alembic/versions/0c1f90e75094_add_treatment_to_projects.py
+++ b/alembic/versions/0c1f90e75094_add_treatment_to_projects.py
@@ -1,0 +1,28 @@
+"""add treatment to projects
+
+Revision ID: 0c1f90e75094
+Revises: 6e5f66eedef6
+Create Date: 2025-08-14 00:00:00.000000+00:00
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0c1f90e75094"
+down_revision: Union[str, Sequence[str], None] = "6e5f66eedef6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("projects", sa.Column("treatment", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("projects", "treatment")
+

--- a/app/ai/router.py
+++ b/app/ai/router.py
@@ -115,7 +115,9 @@ async def generate_treatment(
     )
     async with OllamaClient() as client:
         text = await client.generate(model=model, prompt=prompt)
-    return {"treatment": text.strip()}
+    project.treatment = text.strip()
+    await session.commit()
+    return {"treatment": project.treatment}
 
 
 # ---------- Turning Points ----------

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -43,6 +43,7 @@ class Project(Base):
     name: Mapped[str] = mapped_column(String(128))
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     synopsis: Mapped[str | None] = mapped_column(Text, nullable=True)
+    treatment: Mapped[str | None] = mapped_column(Text, nullable=True)
     owner_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/scripts/demo_treatment_persistence.py
+++ b/scripts/demo_treatment_persistence.py
@@ -1,0 +1,34 @@
+"""Manual script to verify treatment persistence for a project.
+
+Usage:
+    poetry run python scripts/demo_treatment_persistence.py <project_id> <treatment_text>
+
+The script updates the treatment of the given project and prints the stored
+value, ensuring it is correctly associated with the project ID.
+"""
+
+import asyncio
+import sys
+
+from app.db.database import SessionLocal
+from app.db.models import Project
+
+
+async def main(project_id: str, treatment: str) -> None:
+    async with SessionLocal() as session:
+        project = await session.get(Project, project_id)
+        if not project:
+            print("Project not found")
+            return
+        project.treatment = treatment
+        await session.commit()
+        refreshed = await session.get(Project, project_id)
+        print("Stored treatment:", refreshed.treatment)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python scripts/demo_treatment_persistence.py <project_id> <treatment_text>")
+    else:
+        asyncio.run(main(sys.argv[1], sys.argv[2]))
+

--- a/tests/test_treatment_persistence.py
+++ b/tests/test_treatment_persistence.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+
+def test_treatment_persists():
+    pytest.importorskip("sqlalchemy")
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+    from app.db.models import Base, Project, gen_uuid
+    import asyncio
+
+    async def run() -> None:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        async_session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+        async with async_session() as session:
+            project = Project(id=gen_uuid(), name="Test Project")
+            session.add(project)
+            await session.commit()
+            project.treatment = "Sample treatment"
+            await session.commit()
+            refreshed = await session.get(Project, project.id)
+            assert refreshed.treatment == "Sample treatment"
+
+    asyncio.run(run())
+
+
+def test_dummy():
+    assert True
+


### PR DESCRIPTION
## Summary
- add optional `treatment` field to `Project` model
- persist AI generated treatment text for projects
- include migration, script, and test for treatment persistence

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689dd66f760883328f3a87d5a64dbb96