### PR TITLE
feat: add project treatment field

### DIFF
--- a/alembic/versions/731651cbf334_add_treatment_to_projects.py
+++ b/alembic/versions/731651cbf334_add_treatment_to_projects.py
@@ -1,0 +1,26 @@
+"""add treatment to projects
+
+Revision ID: 731651cbf334
+Revises: 6e5f66eedef6
+Create Date: 2025-08-14 00:00:00.000000+00:00
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "731651cbf334"
+down_revision: Union[str, Sequence[str], None] = "6e5f66eedef6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("projects", sa.Column("treatment", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("projects", "treatment")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -43,6 +43,7 @@ class Project(Base):
     name: Mapped[str] = mapped_column(String(128))
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     synopsis: Mapped[str | None] = mapped_column(Text, nullable=True)
+    treatment: Mapped[str | None] = mapped_column(Text, nullable=True)
     owner_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/app/projects/router.py
+++ b/app/projects/router.py
@@ -10,30 +10,39 @@ from app.db.models import Project
 
 router = APIRouter(prefix="/projects", tags=["Projects"])
 
+
 class ProjectCreate(BaseModel):
     name: str = Field(min_length=2, max_length=128)
     description: Optional[str] = None
+    treatment: Optional[str] = None
+
 
 class ProjectUpdate(BaseModel):
     name: Optional[str] = Field(default=None, min_length=2, max_length=128)
     description: Optional[str] = None
+    treatment: Optional[str] = None
+
 
 class ProjectOut(BaseModel):
     id: str
     name: str
     description: Optional[str]
+    treatment: Optional[str]
     owner_id: str
     created_at: str
     updated_at: str
 
+
 def _iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
 
 def _ensure_owner(p: Project, user_id: str):
     if not p:
         raise HTTPException(404, "Project not found.")
     if p.owner_id != user_id:
         raise HTTPException(403, "Forbidden.")
+
 
 @router.get("", response_model=list[ProjectOut])
 async def list_projects(
@@ -45,10 +54,19 @@ async def list_projects(
     if q:
         stmt = stmt.where(Project.name.ilike(f"%{q}%"))
     rows = (await session.execute(stmt)).scalars().all()
-    return [ProjectOut(
-        id=r.id, name=r.name, description=r.description, owner_id=r.owner_id,
-        created_at=r.created_at.isoformat(), updated_at=r.updated_at.isoformat()
-    ) for r in rows]
+    return [
+        ProjectOut(
+            id=r.id,
+            name=r.name,
+            description=r.description,
+            treatment=r.treatment,
+            owner_id=r.owner_id,
+            created_at=r.created_at.isoformat(),
+            updated_at=r.updated_at.isoformat(),
+        )
+        for r in rows
+    ]
+
 
 @router.post("", response_model=ProjectOut, status_code=201)
 async def create_project(
@@ -56,23 +74,44 @@ async def create_project(
     me: Annotated[UserPublic, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ):
-    p = Project(name=payload.name, description=payload.description, owner_id=me.id)
+    p = Project(
+        name=payload.name,
+        description=payload.description,
+        treatment=payload.treatment,
+        owner_id=me.id,
+    )
     session.add(p)
     await session.commit()
     await session.refresh(p)
     return ProjectOut(
-        id=p.id, name=p.name, description=p.description, owner_id=p.owner_id,
-        created_at=p.created_at.isoformat(), updated_at=p.updated_at.isoformat()
+        id=p.id,
+        name=p.name,
+        description=p.description,
+        treatment=p.treatment,
+        owner_id=p.owner_id,
+        created_at=p.created_at.isoformat(),
+        updated_at=p.updated_at.isoformat(),
     )
 
+
 @router.get("/{project_id}", response_model=ProjectOut)
-async def get_project(project_id: str, me: Annotated[UserPublic, Depends(get_current_user)], session: Annotated[AsyncSession, Depends(get_session)]):
+async def get_project(
+    project_id: str,
+    me: Annotated[UserPublic, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+):
     p = await session.get(Project, project_id)
     _ensure_owner(p, me.id)
     return ProjectOut(
-        id=p.id, name=p.name, description=p.description, owner_id=p.owner_id,
-        created_at=p.created_at.isoformat(), updated_at=p.updated_at.isoformat()
+        id=p.id,
+        name=p.name,
+        description=p.description,
+        treatment=p.treatment,
+        owner_id=p.owner_id,
+        created_at=p.created_at.isoformat(),
+        updated_at=p.updated_at.isoformat(),
     )
+
 
 @router.patch("/{project_id}", response_model=ProjectOut)
 async def update_project(
@@ -87,15 +126,27 @@ async def update_project(
         p.name = payload.name
     if payload.description is not None:
         p.description = payload.description
+    if payload.treatment is not None:
+        p.treatment = payload.treatment
     await session.commit()
     await session.refresh(p)
     return ProjectOut(
-        id=p.id, name=p.name, description=p.description, owner_id=p.owner_id,
-        created_at=p.created_at.isoformat(), updated_at=p.updated_at.isoformat()
+        id=p.id,
+        name=p.name,
+        description=p.description,
+        treatment=p.treatment,
+        owner_id=p.owner_id,
+        created_at=p.created_at.isoformat(),
+        updated_at=p.updated_at.isoformat(),
     )
 
+
 @router.delete("/{project_id}", status_code=204)
-async def delete_project(project_id: str, me: Annotated[UserPublic, Depends(get_current_user)], session: Annotated[AsyncSession, Depends(get_session)]):
+async def delete_project(
+    project_id: str,
+    me: Annotated[UserPublic, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+):
     p = await session.get(Project, project_id)
     _ensure_owner(p, me.id)
     await session.delete(p)


### PR DESCRIPTION
## Summary
- allow projects to store an optional treatment
- expose treatment in project API schemas
- add database migration for new treatment column

## Testing
- `poetry run ruff check app/db/models.py app/projects/router.py alembic/versions/731651cbf334_add_treatment_to_projects.py`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e12f3e2a88332ac526fc0533bd471