### PR TITLE
Add project synopsis endpoints

### DIFF
--- a/app/projects/router.py
+++ b/app/projects/router.py
@@ -10,13 +10,16 @@ from app.db.models import Project
 
 router = APIRouter(prefix="/projects", tags=["Projects"])
 
+
 class ProjectCreate(BaseModel):
     name: str = Field(min_length=2, max_length=128)
     description: Optional[str] = None
 
+
 class ProjectUpdate(BaseModel):
     name: Optional[str] = Field(default=None, min_length=2, max_length=128)
     description: Optional[str] = None
+
 
 class ProjectOut(BaseModel):
     id: str
@@ -26,14 +29,25 @@ class ProjectOut(BaseModel):
     created_at: str
     updated_at: str
 
+
+class SynopsisPatch(BaseModel):
+    synopsis: Optional[str] = None
+
+
+class SynopsisOut(BaseModel):
+    synopsis: Optional[str]
+
+
 def _iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
 
 def _ensure_owner(p: Project, user_id: str):
     if not p:
         raise HTTPException(404, "Project not found.")
     if p.owner_id != user_id:
         raise HTTPException(403, "Forbidden.")
+
 
 @router.get("", response_model=list[ProjectOut])
 async def list_projects(
@@ -45,10 +59,18 @@ async def list_projects(
     if q:
         stmt = stmt.where(Project.name.ilike(f"%{q}%"))
     rows = (await session.execute(stmt)).scalars().all()
-    return [ProjectOut(
-        id=r.id, name=r.name, description=r.description, owner_id=r.owner_id,
-        created_at=r.created_at.isoformat(), updated_at=r.updated_at.isoformat()
-    ) for r in rows]
+    return [
+        ProjectOut(
+            id=r.id,
+            name=r.name,
+            description=r.description,
+            owner_id=r.owner_id,
+            created_at=r.created_at.isoformat(),
+            updated_at=r.updated_at.isoformat(),
+        )
+        for r in rows
+    ]
+
 
 @router.post("", response_model=ProjectOut, status_code=201)
 async def create_project(
@@ -61,18 +83,32 @@ async def create_project(
     await session.commit()
     await session.refresh(p)
     return ProjectOut(
-        id=p.id, name=p.name, description=p.description, owner_id=p.owner_id,
-        created_at=p.created_at.isoformat(), updated_at=p.updated_at.isoformat()
+        id=p.id,
+        name=p.name,
+        description=p.description,
+        owner_id=p.owner_id,
+        created_at=p.created_at.isoformat(),
+        updated_at=p.updated_at.isoformat(),
     )
 
+
 @router.get("/{project_id}", response_model=ProjectOut)
-async def get_project(project_id: str, me: Annotated[UserPublic, Depends(get_current_user)], session: Annotated[AsyncSession, Depends(get_session)]):
+async def get_project(
+    project_id: str,
+    me: Annotated[UserPublic, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+):
     p = await session.get(Project, project_id)
     _ensure_owner(p, me.id)
     return ProjectOut(
-        id=p.id, name=p.name, description=p.description, owner_id=p.owner_id,
-        created_at=p.created_at.isoformat(), updated_at=p.updated_at.isoformat()
+        id=p.id,
+        name=p.name,
+        description=p.description,
+        owner_id=p.owner_id,
+        created_at=p.created_at.isoformat(),
+        updated_at=p.updated_at.isoformat(),
     )
+
 
 @router.patch("/{project_id}", response_model=ProjectOut)
 async def update_project(
@@ -90,13 +126,49 @@ async def update_project(
     await session.commit()
     await session.refresh(p)
     return ProjectOut(
-        id=p.id, name=p.name, description=p.description, owner_id=p.owner_id,
-        created_at=p.created_at.isoformat(), updated_at=p.updated_at.isoformat()
+        id=p.id,
+        name=p.name,
+        description=p.description,
+        owner_id=p.owner_id,
+        created_at=p.created_at.isoformat(),
+        updated_at=p.updated_at.isoformat(),
     )
 
+
 @router.delete("/{project_id}", status_code=204)
-async def delete_project(project_id: str, me: Annotated[UserPublic, Depends(get_current_user)], session: Annotated[AsyncSession, Depends(get_session)]):
+async def delete_project(
+    project_id: str,
+    me: Annotated[UserPublic, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+):
     p = await session.get(Project, project_id)
     _ensure_owner(p, me.id)
     await session.delete(p)
     await session.commit()
+
+
+@router.get("/{project_id}/synopsis", response_model=SynopsisOut)
+async def get_synopsis(
+    project_id: str,
+    me: Annotated[UserPublic, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+):
+    p = await session.get(Project, project_id)
+    _ensure_owner(p, me.id)
+    return {"synopsis": p.synopsis}
+
+
+@router.patch("/{project_id}/synopsis", response_model=SynopsisOut)
+async def patch_synopsis(
+    project_id: str,
+    payload: SynopsisPatch,
+    me: Annotated[UserPublic, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+):
+    p = await session.get(Project, project_id)
+    _ensure_owner(p, me.id)
+    if "synopsis" in payload.model_fields_set:
+        p.synopsis = payload.synopsis
+        await session.commit()
+        await session.refresh(p)
+    return {"synopsis": p.synopsis}


### PR DESCRIPTION
## Summary
- add `SynopsisPatch` and `SynopsisOut` models
- support retrieving and updating project synopsis via new endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e12f7a2408332950eeba6265641c1