### PR TITLE
Use treatment for turning points

### DIFF
--- a/app/ai/prompts.py
+++ b/app/ai/prompts.py
@@ -18,7 +18,8 @@ Logline: {logline}
 """
 
 TURNING_POINTS_PROMPT = """Propón 5 Puntos de Giro (S3), con título y descripción (2-3 frases cada uno).
-Género: {genre}. Tema: {theme}. Premisa: {premise}.
+Basados en el siguiente Tratamiento:
+{treatment}
 Devuelve JSON: [{{"id":"TP1","title":"...","description":"..."}}...]
 """
 


### PR DESCRIPTION
## Summary
- simplify `/ai/turning-points` payload to `project_id` and `screenwriter`
- drive turning point generation from stored treatment text
- cover turning points in AI endpoint tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_689e1dfd483c8332aff0e370c5f0c8c1