### PR TITLE
Clarify TURNING_POINTS_PROMPT JSON output requirements

### DIFF
--- a/app/ai/prompts.py
+++ b/app/ai/prompts.py
@@ -20,7 +20,8 @@ Logline: {logline}
 TURNING_POINTS_PROMPT = """Propón 5 Puntos de Giro (S3), con título y descripción (2-3 frases cada uno).
 Basados en el siguiente Tratamiento:
 {treatment}
-Devuelve JSON: [{{"id":"TP1","title":"...","description":"..."}}...]
+Devuelve únicamente un array JSON válido, sin texto adicional ni marcadores de código.
+Ejemplo: [{{"id":"TP1","title":"...","description":"..."}}]
 """
 
 CHARACTER_PROMPT = """Diseña un personaje memorable (S4).


### PR DESCRIPTION
## Summary
- clarify that TURNING_POINTS_PROMPT must return only a valid JSON array
- add example JSON format for turning points response

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_689e223783e883329df5272285c9a457