### PR TITLE
feat: canonical turning points

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Los endpoints que generan contenido aceptan ahora un campo `project_id` para aso
 - `POST /ai/image`
 
 El endpoint `POST /ai/treatment` ahora guarda el tratamiento generado en la base de datos del proyecto asociado.
+`POST /ai/turning-points` genera los cinco Puntos de Giro canónicos (TP1–TP5) devolviendo solo sus descripciones; los títulos se asignan automáticamente.
 
 ### Ejemplo de solicitud
 

--- a/app/ai/prompts.py
+++ b/app/ai/prompts.py
@@ -17,11 +17,19 @@ Basado en la sinopsis proporcionada.
 Logline: {logline}
 """
 
-TURNING_POINTS_PROMPT = """Propón 5 Puntos de Giro (S3), con título y descripción (2-3 frases cada uno).
+TURNING_POINTS_PROMPT = """Enumera los cinco Puntos de Giro canónicos con una breve explicación (2-3 frases) para cada uno:
+
+1. Incidente (Acto I) – invitación a la aventura
+2. Momento de Cambio (fin de Acto I) – decisión que inicia el Acto II
+3. Punto Medio / Ordalía (Acto II, ~min 60) – prueba máxima o punto de no retorno
+4. Crisis (fin de Acto II, ~min 90) – giro que impulsa el desenlace
+5. Clímax (fin de Acto III, ~min 120) – resolución principal
+
 Basados en el siguiente Tratamiento:
 {treatment}
-Devuelve únicamente un array JSON válido, sin texto adicional ni marcadores de código.
-Ejemplo: [{{"id":"TP1","title":"...","description":"..."}}]
+
+Devuelve únicamente un array JSON válido con cinco objetos {id, description} (ids: TP1–TP5), sin texto adicional ni marcadores de código.
+Ejemplo: [{{"id":"TP1","description":"..."}}]
 """
 
 CHARACTER_PROMPT = """Diseña un personaje memorable (S4).

--- a/app/turning_points.py
+++ b/app/turning_points.py
@@ -1,0 +1,7 @@
+TURNING_POINT_TITLES = {
+    "TP1": "Incidente",
+    "TP2": "Momento de Cambio",
+    "TP3": "Punto Medio / Ordalía",
+    "TP4": "Crisis",
+    "TP5": "Clímax",
+}


### PR DESCRIPTION
## Summary
- enumerate canonical turning points and return ids with descriptions
- map turning point ids to fixed titles and store them consistently
- wire title mapping into screenplay updates

## Testing
- `pytest` *(fails: No module named 'sqlalchemy')*
- `pip install sqlalchemy` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e25c8cc648332b14e3068c898b634