### PR TITLE
Add fixed title mapping for turning points

### DIFF
--- a/app/ai/router.py
+++ b/app/ai/router.py
@@ -22,6 +22,15 @@ from .prompts import (
 router = APIRouter(prefix="/ai", tags=["AI"])
 
 
+# Fixed titles for Turning Points keyed by their identifiers
+TURNING_POINT_TITLES = {
+    "TP1": "Inciting Incident",
+    "TP2": "Break into Act Two",
+    "TP3": "Midpoint",
+    "TP4": "Break into Act Three",
+    "TP5": "Climax",
+}
+
 # ---------- Helpers modelo ----------
 def pick_text_model(screenwriter: bool = False):
     return settings.ai_text_screenwriter if screenwriter else settings.ai_text_default
@@ -155,7 +164,14 @@ async def generate_turning_points(
         text = await client.generate(model=model, prompt=prompt)
     try:
         data = json.loads(text)
-        items = [TurningPointItem(**tp) for tp in data]
+        items = [
+            TurningPointItem(
+                id=tp["id"],
+                title=TURNING_POINT_TITLES.get(tp["id"], tp.get("title", "")),
+                description=tp["description"],
+            )
+            for tp in data
+        ]
     except Exception:
         raise HTTPException(502, "AI returned invalid JSON for turning points.")
     screenplay.turning_points = [tp.model_dump() for tp in items]

--- a/app/ai/tests/test_turning_points.py
+++ b/app/ai/tests/test_turning_points.py
@@ -7,6 +7,7 @@ from app.main import app
 from app.db.models import Base, User, Project, Screenplay
 from app.db.database import get_session
 from app.auth.security import get_current_user, UserPublic, hash_password
+from app.ai.router import TURNING_POINT_TITLES
 
 
 @pytest.fixture
@@ -72,12 +73,10 @@ async def create_project_and_screenplay(session, user):
 @pytest.mark.asyncio
 async def test_turning_points_valid_json(client, session, monkeypatch):
     project, screenplay = await create_project_and_screenplay(session, client.user)
-    turning_points = [
-        {"id": "TP1", "title": "Title", "description": "Desc"}
-    ]
+    ai_turning_points = [{"id": "TP1", "description": "Desc"}]
 
     async def fake_generate(self, model, prompt, **kwargs):
-        return json.dumps(turning_points)
+        return json.dumps(ai_turning_points)
 
     monkeypatch.setattr(
         "app.utils.ollama_client.OllamaClient.generate", fake_generate
@@ -88,10 +87,17 @@ async def test_turning_points_valid_json(client, session, monkeypatch):
         json={"project_id": project.id, "screenplay_id": screenplay.id},
     )
     assert resp.status_code == 200
-    assert resp.json()["points"] == turning_points
+    expected = [
+        {
+            "id": "TP1",
+            "title": TURNING_POINT_TITLES["TP1"],
+            "description": "Desc",
+        }
+    ]
+    assert resp.json()["points"] == expected
 
     await session.refresh(screenplay)
-    assert screenplay.turning_points == turning_points
+    assert screenplay.turning_points == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add TURNING_POINT_TITLES mapping and apply titles when generating turning points
- update turning points test to expect titles injected from mapping
- ensure synopsis/treatment flow uses screenplay id and checks stored turning points

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install fastapi==0.115.0 sqlalchemy==2.0.34 pydantic==2.9.2 pydantic-settings==2.0.0 alembic==1.13.2 psycopg[binary]==3.2.9 greenlet==3.0.3 python-dotenv==1.0.1 passlib[bcrypt]==1.7.4 python-jose==3.3.0 cryptography==43.0.1 httpx==0.27.0 pytest==8.3.3 pytest-asyncio==0.24.0 uvicorn==0.30.6` *(fails: Could not find a version that satisfies the requirement fastapi==0.115.0)*

------
https://chatgpt.com/codex/tasks/task_e_689e25d2e6a883329cd54215cc90b4c3