### PR TITLE
Fix KeyError when formatting turning points prompt

### DIFF
--- a/app/ai/prompts.py
+++ b/app/ai/prompts.py
@@ -28,7 +28,7 @@ TURNING_POINTS_PROMPT = """Enumera los cinco Puntos de Giro canónicos con una b
 Basados en el siguiente Tratamiento:
 {treatment}
 
-Devuelve únicamente un array JSON válido con cinco objetos {id, description} (ids: TP1–TP5), sin texto adicional ni marcadores de código.
+Devuelve únicamente un array JSON válido con cinco objetos {{id, description}} (ids: TP1–TP5), sin texto adicional ni marcadores de código.
 Ejemplo: [{{"id":"TP1","description":"..."}}]
 """
 


### PR DESCRIPTION
## Summary
- escape curly braces in turning-points prompt to allow string formatting

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install sqlalchemy` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_689e290ef90c83328712d723c9f704f1