### PR TITLE
Store story details on screenplays

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## AI and Media Endpoints
 
-Los endpoints que generan contenido aceptan ahora un campo `project_id` para asociar los resultados con un proyecto específico.
+Los endpoints que generan contenido aceptan ahora un campo `screenplay_id` para asociar los resultados con un guion específico.
 
 ### Endpoints afectados
 
@@ -15,7 +15,7 @@ Los endpoints que generan contenido aceptan ahora un campo `project_id` para aso
 - `POST /ai/review`
 - `POST /ai/image`
 
-El endpoint `POST /ai/treatment` ahora guarda el tratamiento generado en la base de datos del proyecto asociado.
+El endpoint `POST /ai/treatment` ahora guarda el tratamiento generado en la base de datos del screenplay asociado.
 `POST /ai/turning-points` genera los cinco Puntos de Giro canónicos (TP1–TP5) devolviendo solo sus descripciones, basadas en el Tratamiento; los títulos se asignan automáticamente.
 
 ### Ejemplo de solicitud
@@ -23,7 +23,7 @@ El endpoint `POST /ai/treatment` ahora guarda el tratamiento generado en la base
 ```json
 POST /ai/treatment
 {
-  "project_id": "123",
+  "screenplay_id": "123",
   "logline": "Un ejemplo de logline",
   "tone": "cinematográfico"
 }
@@ -32,39 +32,9 @@ POST /ai/treatment
 ```json
 POST /ai/image
 {
-  "project_id": "123",
+  "screenplay_id": "123",
   "prompt": "Atardecer en la montaña",
   "style": "fast"
-}
-```
-
-## Ejemplos de sinopsis y tratamiento de proyectos
-
-```json
-GET /projects/123/synopsis
-{
-  "synopsis": "Sinopsis actual del proyecto"
-}
-```
-
-```json
-PATCH /projects/123/synopsis
-{
-  "synopsis": "Nueva sinopsis"
-}
-```
-
-```json
-GET /projects/123/treatment
-{
-  "treatment": "Tratamiento almacenado"
-}
-```
-
-```json
-PATCH /projects/123/treatment
-{
-  "treatment": "Tratamiento actualizado"
 }
 ```
 

--- a/alembic/versions/b693b67d3b9a_move_synopsis_treatment_to_screenplays.py
+++ b/alembic/versions/b693b67d3b9a_move_synopsis_treatment_to_screenplays.py
@@ -1,0 +1,31 @@
+"""move synopsis and treatment to screenplays
+
+Revision ID: b693b67d3b9a
+Revises: 0c1f90e75094
+Create Date: 2024-01-01 00:00:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "b693b67d3b9a"
+down_revision: Union[str, Sequence[str], None] = "0c1f90e75094"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("screenplays", sa.Column("synopsis", sa.Text(), nullable=True))
+    op.add_column("screenplays", sa.Column("treatment", sa.Text(), nullable=True))
+    op.drop_column("projects", "synopsis")
+    op.drop_column("projects", "treatment")
+
+
+def downgrade() -> None:
+    op.add_column("projects", sa.Column("treatment", sa.Text(), nullable=True))
+    op.add_column("projects", sa.Column("synopsis", sa.Text(), nullable=True))
+    op.drop_column("screenplays", "treatment")
+    op.drop_column("screenplays", "synopsis")

--- a/app/ai/tests/test_turning_points.py
+++ b/app/ai/tests/test_turning_points.py
@@ -47,7 +47,7 @@ async def client(session):
 
 
 async def create_project_and_screenplay(session, user):
-    project = Project(name="Proj", owner_id=user.id, synopsis="syn", treatment="treat")
+    project = Project(name="Proj", owner_id=user.id)
     session.add(project)
     await session.commit()
     await session.refresh(project)
@@ -57,6 +57,8 @@ async def create_project_and_screenplay(session, user):
         owner_id=user.id,
         title="Script",
         logline=None,
+        synopsis="syn",
+        treatment="treat",
         state="S1",
         turning_points=[],
         characters=[],
@@ -82,7 +84,7 @@ async def test_turning_points_valid_json(client, session, monkeypatch):
 
     resp = await client.post(
         "/ai/turning-points",
-        json={"project_id": project.id, "screenplay_id": screenplay.id},
+        json={"screenplay_id": screenplay.id},
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -112,7 +114,7 @@ async def test_turning_points_invalid_json(client, session, monkeypatch):
 
     resp = await client.post(
         "/ai/turning-points",
-        json={"project_id": project.id, "screenplay_id": screenplay.id},
+        json={"screenplay_id": screenplay.id},
     )
     assert resp.status_code == 502
     data = resp.json()["detail"]

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -42,8 +42,6 @@ class Project(Base):
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=gen_uuid)
     name: Mapped[str] = mapped_column(String(128))
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
-    synopsis: Mapped[str | None] = mapped_column(Text, nullable=True)
-    treatment: Mapped[str | None] = mapped_column(Text, nullable=True)
     owner_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
@@ -66,6 +64,8 @@ class Screenplay(Base):
     )
     title: Mapped[str] = mapped_column(String(200))
     logline: Mapped[str | None] = mapped_column(Text, nullable=True)
+    synopsis: Mapped[str | None] = mapped_column(Text, nullable=True)
+    treatment: Mapped[str | None] = mapped_column(Text, nullable=True)
     state: Mapped[str] = mapped_column(String(16), default="S1")
 
     turning_points: Mapped[list[dict]] = mapped_column(

--- a/app/media/router.py
+++ b/app/media/router.py
@@ -7,7 +7,7 @@ router = APIRouter(prefix="/media", tags=["AI", "Media"])
 class ImageIn(BaseModel):
     prompt: str
     style: str  # "fast" | "quality"
-    project_id: str
+    screenplay_id: str
 
 class ImageOut(BaseModel):
     url: str

--- a/app/screenplays/router.py
+++ b/app/screenplays/router.py
@@ -56,11 +56,15 @@ class ScreenplayCreate(BaseModel):
     project_id: str
     title: str
     logline: Optional[str] = None
+    synopsis: Optional[str] = None
+    treatment: Optional[str] = None
 
 
 class ScreenplayUpdate(BaseModel):
     title: Optional[str] = Field(default=None, min_length=1)
     logline: Optional[str] = None
+    synopsis: Optional[str] = None
+    treatment: Optional[str] = None
     state: Optional[WorkflowState] = None
     turning_points: Optional[list[TurningPointBase]] = None
     characters: Optional[list[Character]] = None
@@ -75,6 +79,8 @@ class ScreenplayOut(BaseModel):
     owner_id: str
     title: str
     logline: Optional[str]
+    synopsis: Optional[str]
+    treatment: Optional[str]
     state: WorkflowState
     turning_points: list[TurningPoint]
     characters: list[Character]
@@ -104,6 +110,8 @@ async def create_screenplay(
         owner_id=me.id,
         title=payload.title,
         logline=payload.logline,
+        synopsis=payload.synopsis,
+        treatment=payload.treatment,
         state="S1",
         turning_points=[],
         characters=[],
@@ -120,6 +128,8 @@ async def create_screenplay(
         owner_id=sp.owner_id,
         title=sp.title,
         logline=sp.logline,
+        synopsis=sp.synopsis,
+        treatment=sp.treatment,
         state=sp.state,
         turning_points=sp.turning_points,
         characters=sp.characters,
@@ -146,6 +156,8 @@ async def get_screenplay(
         owner_id=sp.owner_id,
         title=sp.title,
         logline=sp.logline,
+        synopsis=sp.synopsis,
+        treatment=sp.treatment,
         state=sp.state,
         turning_points=sp.turning_points,
         characters=sp.characters,
@@ -170,6 +182,8 @@ async def update_screenplay(
     for field in [
         "title",
         "logline",
+        "synopsis",
+        "treatment",
         "state",
         "turning_points",
         "characters",
@@ -212,6 +226,8 @@ async def update_screenplay(
         owner_id=sp.owner_id,
         title=sp.title,
         logline=sp.logline,
+        synopsis=sp.synopsis,
+        treatment=sp.treatment,
         state=sp.state,
         turning_points=sp.turning_points,
         characters=sp.characters,

--- a/scripts/demo_treatment_persistence.py
+++ b/scripts/demo_treatment_persistence.py
@@ -1,34 +1,34 @@
-"""Manual script to verify treatment persistence for a project.
+"""Manual script to verify treatment persistence for a screenplay.
 
 Usage:
-    poetry run python scripts/demo_treatment_persistence.py <project_id> <treatment_text>
+    poetry run python scripts/demo_treatment_persistence.py <screenplay_id> <treatment_text>
 
-The script updates the treatment of the given project and prints the stored
-value, ensuring it is correctly associated with the project ID.
+The script updates the treatment of the given screenplay and prints the stored
+value, ensuring it is correctly associated with the screenplay ID.
 """
 
 import asyncio
 import sys
 
 from app.db.database import SessionLocal
-from app.db.models import Project
+from app.db.models import Screenplay
 
 
-async def main(project_id: str, treatment: str) -> None:
+async def main(screenplay_id: str, treatment: str) -> None:
     async with SessionLocal() as session:
-        project = await session.get(Project, project_id)
-        if not project:
-            print("Project not found")
+        sp = await session.get(Screenplay, screenplay_id)
+        if not sp:
+            print("Screenplay not found")
             return
-        project.treatment = treatment
+        sp.treatment = treatment
         await session.commit()
-        refreshed = await session.get(Project, project_id)
+        refreshed = await session.get(Screenplay, screenplay_id)
         print("Stored treatment:", refreshed.treatment)
 
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
-        print("Usage: python scripts/demo_treatment_persistence.py <project_id> <treatment_text>")
+        print("Usage: python scripts/demo_treatment_persistence.py <screenplay_id> <treatment_text>")
     else:
         asyncio.run(main(sys.argv[1], sys.argv[2]))
 


### PR DESCRIPTION
## Summary
- move synopsis and treatment fields from projects to screenplays
- require `screenplay_id` in AI and media POST bodies
- adjust APIs, docs, tests, and migrations accordingly

## Testing
- `pytest` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_689e480522188332b3efd15b139f1498